### PR TITLE
Updates test configuration

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -55,6 +55,7 @@ jobs:
           TF_VAR_git_org: ${{ steps.variables.outputs.org }}
           TF_VAR_git_repo: ${{ steps.variables.outputs.repo }}
           TF_VAR_bootstrap_prefix: ${{ steps.variables.outputs.repo }}
+          TF_VAR_cp_entitlement_key: ${{ secrets.CP_ENTITLEMENT_KEY }}
           TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
           IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
 
@@ -69,6 +70,7 @@ jobs:
           TF_VAR_git_org: ${{ steps.variables.outputs.org }}
           TF_VAR_git_repo: ${{ steps.variables.outputs.repo }}
           TF_VAR_bootstrap_prefix: ${{ steps.variables.outputs.repo }}
+          TF_VAR_cp_entitlement_key: ${{ secrets.CP_ENTITLEMENT_KEY }}
           TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
           IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
 

--- a/test/stages/stage1-cp-catalogs.tf
+++ b/test/stages/stage1-cp-catalogs.tf
@@ -1,0 +1,9 @@
+module "cp_catalogs" {
+  source = "github.com/cloud-native-toolkit/terraform-gitops-cp-catalogs.git"
+
+  gitops_config = module.gitops.gitops_config
+  git_credentials = module.gitops.git_credentials
+  server_name = module.gitops.server_name
+  kubeseal_cert = module.gitops.sealed_secrets_cert
+  entitlement_key = var.cp_entitlement_key
+}

--- a/test/stages/stage1-gitops-bootstrap.tf
+++ b/test/stages/stage1-gitops-bootstrap.tf
@@ -9,4 +9,5 @@ module "gitops-bootstrap" {
   sealed_secret_cert  = module.cert.cert
   sealed_secret_private_key = module.cert.private_key
   prefix              = var.bootstrap_prefix
+  kubeseal_namespace  = var.kubeseal_namespace
 }

--- a/test/stages/variables.tf
+++ b/test/stages/variables.tf
@@ -81,3 +81,7 @@ variable "gitops_namespace" {
 
 variable "git_username" {
 }
+
+variable "kubeseal_namespace" {
+  default = "sealed-secrets"
+}

--- a/test/stages/variables.tf
+++ b/test/stages/variables.tf
@@ -85,3 +85,6 @@ variable "git_username" {
 variable "kubeseal_namespace" {
   default = "sealed-secrets"
 }
+
+variable "cp_entitlement_key" {
+}


### PR DESCRIPTION
- Adds kubeseal_namespace variable that can be overridden for each test case
- Adds cp_entitlement_key that is populated from a GitHub secret
- Adds cp-catalogs test stage to use the cp_entitlement_key